### PR TITLE
refactor: use go-ucanto's delegation.Format

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -108,7 +108,7 @@ func mkDelegation(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("making delegation: %w", err)
 	}
 
-	out, err := mkd.FormatDelegation(d.Archive())
+	out, err := delegation.Format(d)
 	if err != nil {
 		return fmt.Errorf("formatting delegation: %w", err)
 	}

--- a/pkg/delegation/delegation.go
+++ b/pkg/delegation/delegation.go
@@ -3,14 +3,9 @@ package delegation
 import (
 	"encoding/base64"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
-	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multibase"
-	"github.com/multiformats/go-multicodec"
-	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-ucanto/core/dag/blockstore"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/ucan"
@@ -32,40 +27,6 @@ func MakeDelegation(issuer ucan.Signer, audience ucan.Principal, capabilities []
 		uc,
 		opts...,
 	)
-}
-
-// FormatDelegation takes a delegation archive from a read and returns a multibase-base64-encoded CIDv1 with
-// embedded CAR data.
-func FormatDelegation(d io.Reader) (string, error) {
-	db, err := io.ReadAll(d)
-	if err != nil {
-		return "", fmt.Errorf("failed to read delegation: %w", err)
-	}
-
-	return FormatDelegationBytes(db)
-}
-
-// FormatDelegationBytes takes a delegation archive in byte form and returns a multibase-base64-encoded CIDv1 with
-// embedded CAR data.
-func FormatDelegationBytes(archive []byte) (string, error) {
-	// Create identity digest of the archive
-	// The identity hash function (0x00) simply returns the input data as the hash
-	mh, err := multihash.Sum(archive, multihash.IDENTITY, -1)
-	if err != nil {
-		return "", fmt.Errorf("failed to create identity hash: %w", err)
-	}
-
-	// Create a CID (Content IDentifier) with codec 0x0202 (CAR format)
-	// The 0x0202 codec is defined in the multicodec table for Content Addressable aRchives (CAR)
-	link := cid.NewCidV1(uint64(multicodec.Car), mh)
-
-	// Convert the CID to base64 encoding
-	str, err := link.StringOfBase(multibase.Base64)
-	if err != nil {
-		return "", fmt.Errorf("failed to encode CID to base64: %w", err)
-	}
-
-	return str, nil
 }
 
 // CapabilityInfo represents a capability in a delegation


### PR DESCRIPTION
Use `delegation.Format` from `go-ucanto` library and remove formatting functions that do essentially the same.

The tests were also refactored a bit.